### PR TITLE
breaking: drop "esm" dep and only publish native ES Modules build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM emscripten/emsdk:3.1.17
+FROM emscripten/emsdk:3.1.18
 
 RUN apt-get update
 RUN apt-get install gperf

--- a/build.sh
+++ b/build.sh
@@ -51,12 +51,9 @@ sed -r 's/\(function\(\)\{// ; s/\}\)\(\);//' ./build/snudown_oneline.js > ./bui
 # Convert window exports to ES exports
 sed -r 's/,window\.(\w+)=function/;export function \1/g' ./build/snudown_uglify.js > ./build/snudown_exports.js
 
-# Generate modules
+# Generate dist files
 mkdir -p "dist"
-echo "module.exports = require('esm')(module, { mode: 'all' })('./snudown_es.js');" > ./dist/snudown.js
-cp ./build/snudown_exports.js ./dist/snudown_es.js
-
-# Copy TypeScript definitions
+cp ./build/snudown_exports.js ./dist/snudown.js
 cp ./snudown.d.ts ./dist/snudown.d.ts
 
 rm -r "build"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snudown-js",
-  "version": "3.3.0",
+  "version": "4.0.0",
   "description": "a 'native' port of Snudown to JavaScript",
   "type": "module",
   "module": "./dist/snudown.js",
@@ -14,6 +14,5 @@
     "uglify-js": "3.16.3"
   },
   "license": "MIT",
-  "dependencies": {
-  }
+  "dependencies": {}
 }

--- a/package.json
+++ b/package.json
@@ -2,9 +2,10 @@
   "name": "snudown-js",
   "version": "3.3.0",
   "description": "a 'native' port of Snudown to JavaScript",
-  "main": "dist/snudown.js",
-  "module": "dist/snudown_es.js",
-  "types": "dist/snudown.d.ts",
+  "type": "module",
+  "module": "./dist/snudown.js",
+  "exports": "./dist/snudown.js",
+  "types": "./dist/snudown.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/erikdesjardins/snudown-js.git"
@@ -14,6 +15,5 @@
   },
   "license": "MIT",
   "dependencies": {
-    "esm": "^3.0.28"
   }
 }

--- a/test_snudown.js
+++ b/test_snudown.js
@@ -1,4 +1,4 @@
-var Snudown = require('.');
+import * as Snudown from 'snudown-js';
 
 // http://ecmanaut.blogspot.ca/2006/07/encoding-decoding-utf8-in-javascript.html
 function encodeUTF8(s) {


### PR DESCRIPTION
fixes #36

could continue to publish a non-modules build, but even the oldest lts node version should work with this, and any remotely modern bundler will support esm, so it's not worth requiring consumers to install the almost-always-useless `esm` dep