### PR TITLE
match updated old reddit rendering of an inline spoiler with a leading space.

### DIFF
--- a/src/markdown.c
+++ b/src/markdown.c
@@ -637,7 +637,7 @@ char_emphasis(struct buf *ob, struct sd_markdown *rndr, uint8_t *data, size_t ma
 	size_t ret;
 
 	if (size > 3 && c == '>' && data[1] == '!') {
-		if(_isspace(data[2]) || (ret = parse_spoilerspan(ob, rndr, data + 2, size - 2)) == 0)
+		if((ret = parse_spoilerspan(ob, rndr, data + 2, size - 2)) == 0)
 			return 0;
 
 		return ret + 2;

--- a/test_snudown.js
+++ b/test_snudown.js
@@ -398,12 +398,14 @@ var cases = {
         '<blockquote>\n<p>some quote goes here</p>\n</blockquote>\n',
     'This is an >!inline spoiler!< sentence.':
         '<p>This is an <span class="md-spoiler-text">inline spoiler</span> sentence.</p>\n',
+    'This is an >! inline spoiler with a leading space!< sentence.':
+        '<p>This is an <span class="md-spoiler-text"> inline spoiler with a leading space</span> sentence.</p>\n',
     '>!Inline spoiler!< starting the sentence':
         '<p><span class="md-spoiler-text">Inline spoiler</span> starting the sentence</p>\n',
     'Inline >!spoiler with *emphasis*!< test':
         '<p>Inline <span class="md-spoiler-text">spoiler with <em>emphasis</em></span> test</p>\n',
     '>! This is an illegal blockspoiler >!with an inline spoiler!<':
-        '<p>&gt;! This is an illegal blockspoiler <span class="md-spoiler-text">with an inline spoiler</span></p>\n',
+        '<p><span class="md-spoiler-text"> This is an illegal blockspoiler &gt;!with an inline spoiler</span></p>\n',
     'This is an >!inline spoiler with some >!additional!< text!<':
         '<p>This is an <span class="md-spoiler-text">inline spoiler with some &gt;!additional</span> text!&lt;</p>\n'
 };


### PR DESCRIPTION
Some time around Fall 2025, reddit updated old reddit to support inline spoiler tags with leading spaces. You can see an example of it now working [here](https://old.reddit.com/r/anime/comments/1tqkx5g/casual_discussion_fridays_week_of_may_29_2026/oopjdvq/).

The illegal blockspoiler test was changed because the current reddit behavior is now different as well. You can see that [here](https://old.reddit.com/r/anime/comments/1tqkx5g/casual_discussion_fridays_week_of_may_29_2026/oopklgp/?context=10000). I would imagine that just outright removing that test might be better, but I'll leave that up to you, since I'm not at all familiar with blockspoilers (I discovered they were a thing from this).